### PR TITLE
fix: vercel static export path

### DIFF
--- a/.changeset/six-jars-push.md
+++ b/.changeset/six-jars-push.md
@@ -1,0 +1,5 @@
+---
+"astro": patch
+---
+
+Provide correct MIME type for dynamic endpoint routes in dev

--- a/packages/astro/e2e/astro-component.test.js
+++ b/packages/astro/e2e/astro-component.test.js
@@ -6,11 +6,11 @@ const test = testFactory({ root: './fixtures/astro-component/' });
 
 let devServer;
 
-test.beforeEach(async ({ astro }) => {
+test.beforeAll(async ({ astro }) => {
 	devServer = await astro.startDevServer();
 });
 
-test.afterEach(async () => {
+test.afterAll(async () => {
 	await devServer.stop();
 });
 

--- a/packages/astro/e2e/client-only.test.js
+++ b/packages/astro/e2e/client-only.test.js
@@ -5,11 +5,11 @@ const test = testFactory({ root: './fixtures/client-only/' });
 
 let devServer;
 
-test.beforeEach(async ({ astro }) => {
+test.beforeAll(async ({ astro }) => {
 	devServer = await astro.startDevServer();
 });
 
-test.afterEach(async () => {
+test.afterAll(async () => {
 	await devServer.stop();
 });
 

--- a/packages/astro/e2e/error-react-spectrum.test.js
+++ b/packages/astro/e2e/error-react-spectrum.test.js
@@ -5,13 +5,12 @@ const test = testFactory({ root: './fixtures/error-react-spectrum/' });
 
 let devServer;
 
-test.beforeEach(async ({ astro }) => {
+test.beforeAll(async ({ astro }) => {
 	devServer = await astro.startDevServer();
 });
 
-test.afterEach(async ({ astro }) => {
+test.afterAll(async ({ astro }) => {
 	await devServer.stop();
-	astro.resetAllFiles();
 });
 
 test.describe('Error: React Spectrum', () => {

--- a/packages/astro/e2e/error-sass.test.js
+++ b/packages/astro/e2e/error-sass.test.js
@@ -5,11 +5,11 @@ const test = testFactory({ root: './fixtures/error-sass/' });
 
 let devServer;
 
-test.beforeEach(async ({ astro }) => {
+test.beforeAll(async ({ astro }) => {
 	devServer = await astro.startDevServer();
 });
 
-test.afterEach(async ({ astro }) => {
+test.afterAll(async ({ astro }) => {
 	await devServer.stop();
 	astro.resetAllFiles();
 });

--- a/packages/astro/e2e/errors.test.js
+++ b/packages/astro/e2e/errors.test.js
@@ -5,11 +5,11 @@ const test = testFactory({ root: './fixtures/errors/' });
 
 let devServer;
 
-test.beforeEach(async ({ astro }) => {
+test.beforeAll(async ({ astro }) => {
 	devServer = await astro.startDevServer();
 });
 
-test.afterEach(async ({ astro }) => {
+test.afterAll(async ({ astro }) => {
 	await devServer.stop();
 	astro.resetAllFiles();
 });

--- a/packages/astro/e2e/invalidate-script-deps.test.js
+++ b/packages/astro/e2e/invalidate-script-deps.test.js
@@ -7,11 +7,11 @@ const test = testFactory({
 
 let devServer;
 
-test.beforeEach(async ({ astro }) => {
+test.beforeAll(async ({ astro }) => {
 	devServer = await astro.startDevServer();
 });
 
-test.afterEach(async () => {
+test.afterAll(async () => {
 	await devServer.stop();
 });
 

--- a/packages/astro/e2e/lit-component.test.js
+++ b/packages/astro/e2e/lit-component.test.js
@@ -8,7 +8,7 @@ const test = testFactory({
 // TODO: configure playwright to handle web component APIs
 // https://github.com/microsoft/playwright/issues/14241
 test.describe('Lit components', () => {
-	test.beforeEach(() => {
+	test.beforeAll(() => {
 		delete globalThis.window;
 	});
 
@@ -16,11 +16,11 @@ test.describe('Lit components', () => {
 		let devServer;
 		const t = test.extend({});
 
-		t.beforeEach(async ({ astro }) => {
+		t.beforeAll(async ({ astro }) => {
 			devServer = await astro.startDevServer();
 		});
 
-		t.afterEach(async () => {
+		t.afterAll(async () => {
 			await devServer.stop();
 		});
 
@@ -120,11 +120,11 @@ test.describe('Lit components', () => {
 			await astro.build();
 		});
 
-		t.beforeEach(async ({ astro }) => {
+		t.beforeAll(async ({ astro }) => {
 			previewServer = await astro.preview();
 		});
 
-		t.afterEach(async () => {
+		t.afterAll(async () => {
 			await previewServer.stop();
 		});
 

--- a/packages/astro/e2e/multiple-frameworks.test.js
+++ b/packages/astro/e2e/multiple-frameworks.test.js
@@ -5,11 +5,11 @@ const test = testFactory({ root: './fixtures/multiple-frameworks/' });
 
 let devServer;
 
-test.beforeEach(async ({ astro }) => {
+test.beforeAll(async ({ astro }) => {
 	devServer = await astro.startDevServer();
 });
 
-test.afterEach(async () => {
+test.afterAll(async () => {
 	await devServer.stop();
 });
 

--- a/packages/astro/e2e/namespaced-component.test.js
+++ b/packages/astro/e2e/namespaced-component.test.js
@@ -7,11 +7,11 @@ const test = testFactory({
 
 let devServer;
 
-test.beforeEach(async ({ astro }) => {
+test.beforeAll(async ({ astro }) => {
 	devServer = await astro.startDevServer();
 });
 
-test.afterEach(async () => {
+test.afterAll(async () => {
 	await devServer.stop();
 });
 

--- a/packages/astro/e2e/nested-in-preact.test.js
+++ b/packages/astro/e2e/nested-in-preact.test.js
@@ -5,11 +5,11 @@ const test = testFactory({ root: './fixtures/nested-in-preact/' });
 
 let devServer;
 
-test.beforeEach(async ({ astro }) => {
+test.beforeAll(async ({ astro }) => {
 	devServer = await astro.startDevServer();
 });
 
-test.afterEach(async () => {
+test.afterAll(async () => {
 	await devServer.stop();
 });
 

--- a/packages/astro/e2e/nested-in-react.test.js
+++ b/packages/astro/e2e/nested-in-react.test.js
@@ -5,11 +5,11 @@ const test = testFactory({ root: './fixtures/nested-in-react/' });
 
 let devServer;
 
-test.beforeEach(async ({ astro }) => {
+test.beforeAll(async ({ astro }) => {
 	devServer = await astro.startDevServer();
 });
 
-test.afterEach(async () => {
+test.afterAll(async () => {
 	await devServer.stop();
 });
 

--- a/packages/astro/e2e/nested-in-solid.test.js
+++ b/packages/astro/e2e/nested-in-solid.test.js
@@ -5,11 +5,11 @@ const test = testFactory({ root: './fixtures/nested-in-solid/' });
 
 let devServer;
 
-test.beforeEach(async ({ astro }) => {
+test.beforeAll(async ({ astro }) => {
 	devServer = await astro.startDevServer();
 });
 
-test.afterEach(async () => {
+test.afterAll(async () => {
 	await devServer.stop();
 });
 

--- a/packages/astro/e2e/nested-in-svelte.test.js
+++ b/packages/astro/e2e/nested-in-svelte.test.js
@@ -5,11 +5,11 @@ const test = testFactory({ root: './fixtures/nested-in-svelte/' });
 
 let devServer;
 
-test.beforeEach(async ({ astro }) => {
+test.beforeAll(async ({ astro }) => {
 	devServer = await astro.startDevServer();
 });
 
-test.afterEach(async () => {
+test.afterAll(async () => {
 	await devServer.stop();
 });
 

--- a/packages/astro/e2e/nested-in-vue.test.js
+++ b/packages/astro/e2e/nested-in-vue.test.js
@@ -5,11 +5,11 @@ const test = testFactory({ root: './fixtures/nested-in-vue/' });
 
 let devServer;
 
-test.beforeEach(async ({ astro }) => {
+test.beforeAll(async ({ astro }) => {
 	devServer = await astro.startDevServer();
 });
 
-test.afterEach(async () => {
+test.afterAll(async () => {
 	await devServer.stop();
 });
 

--- a/packages/astro/e2e/nested-recursive.test.js
+++ b/packages/astro/e2e/nested-recursive.test.js
@@ -10,11 +10,11 @@ const test = base.extend({
 
 let devServer;
 
-test.beforeEach(async ({ astro }) => {
+test.beforeAll(async ({ astro }) => {
 	devServer = await astro.startDevServer();
 });
 
-test.afterEach(async () => {
+test.afterAll(async () => {
 	await devServer.stop();
 });
 

--- a/packages/astro/e2e/nested-styles.test.js
+++ b/packages/astro/e2e/nested-styles.test.js
@@ -5,11 +5,11 @@ const test = testFactory({ root: './fixtures/nested-styles/' });
 
 let devServer;
 
-test.beforeEach(async ({ astro }) => {
+test.beforeAll(async ({ astro }) => {
 	devServer = await astro.startDevServer();
 });
 
-test.afterEach(async () => {
+test.afterAll(async () => {
 	await devServer.stop();
 });
 

--- a/packages/astro/e2e/pass-js.test.js
+++ b/packages/astro/e2e/pass-js.test.js
@@ -7,11 +7,11 @@ const test = testFactory({
 
 let devServer;
 
-test.beforeEach(async ({ astro }) => {
+test.beforeAll(async ({ astro }) => {
 	devServer = await astro.startDevServer();
 });
 
-test.afterEach(async () => {
+test.afterAll(async () => {
 	await devServer.stop();
 });
 

--- a/packages/astro/e2e/shared-component-tests.js
+++ b/packages/astro/e2e/shared-component-tests.js
@@ -6,11 +6,11 @@ export function prepareTestFactory(opts) {
 
 	let devServer;
 
-	test.beforeEach(async ({ astro }) => {
+	test.beforeAll(async ({ astro }) => {
 		devServer = await astro.startDevServer();
 	});
 
-	test.afterEach(async () => {
+	test.afterAll(async () => {
 		await devServer.stop();
 	});
 

--- a/packages/astro/e2e/solid-recurse.test.js
+++ b/packages/astro/e2e/solid-recurse.test.js
@@ -5,11 +5,11 @@ const test = testFactory({ root: './fixtures/solid-recurse/' });
 
 let devServer;
 
-test.beforeEach(async ({ astro }) => {
+test.beforeAll(async ({ astro }) => {
 	devServer = await astro.startDevServer();
 });
 
-test.afterEach(async () => {
+test.afterAll(async () => {
 	await devServer.stop();
 });
 

--- a/packages/astro/e2e/tailwindcss.test.js
+++ b/packages/astro/e2e/tailwindcss.test.js
@@ -5,11 +5,11 @@ const test = testFactory({ root: './fixtures/tailwindcss/' });
 
 let devServer;
 
-test.beforeEach(async ({ astro }) => {
+test.beforeAll(async ({ astro }) => {
 	devServer = await astro.startDevServer();
 });
 
-test.afterEach(async ({ astro }) => {
+test.afterAll(async ({ astro }) => {
 	await devServer.stop();
 	astro.resetAllFiles();
 });

--- a/packages/astro/e2e/test-utils.js
+++ b/packages/astro/e2e/test-utils.js
@@ -18,7 +18,7 @@ export function testFactory(inlineConfig) {
 
 	const test = testBase.extend({
 		astro: async ({}, use) => {
-			fixture = fixture || await loadFixture(inlineConfig);
+			fixture = fixture || (await loadFixture(inlineConfig));
 			await use(fixture);
 		},
 	});

--- a/packages/astro/e2e/test-utils.js
+++ b/packages/astro/e2e/test-utils.js
@@ -18,7 +18,7 @@ export function testFactory(inlineConfig) {
 
 	const test = testBase.extend({
 		astro: async ({}, use) => {
-			fixture = await loadFixture(inlineConfig);
+			fixture = fixture || await loadFixture(inlineConfig);
 			await use(fixture);
 		},
 	});

--- a/packages/astro/e2e/ts-resolution.test.js
+++ b/packages/astro/e2e/ts-resolution.test.js
@@ -26,11 +26,11 @@ test.describe('TypeScript resolution -', () => {
 
 		let devServer;
 
-		t.beforeEach(async ({ astro }) => {
+		t.beforeAll(async ({ astro }) => {
 			devServer = await astro.startDevServer();
 		});
 
-		t.afterEach(async () => {
+		t.afterAll(async () => {
 			await devServer.stop();
 		});
 
@@ -44,13 +44,10 @@ test.describe('TypeScript resolution -', () => {
 
 		t.beforeAll(async ({ astro }) => {
 			await astro.build();
-		});
-
-		t.beforeEach(async ({ astro }) => {
 			previewServer = await astro.preview();
 		});
 
-		t.afterEach(async () => {
+		t.afterAll(async () => {
 			await previewServer.stop();
 		});
 

--- a/packages/astro/src/vite-plugin-astro-server/index.ts
+++ b/packages/astro/src/vite-plugin-astro-server/index.ts
@@ -345,7 +345,11 @@ async function handleRequest(
 				await writeWebResponse(res, result.response);
 			} else {
 				let contentType = 'text/plain';
-				const computedMimeType = route.pathname ? mime.getType(route.pathname) : null;
+				// Dynamic routes don’t include `route.pathname`, so synthesise a path for these (e.g. 'src/pages/[slug].svg')
+				const filepath =
+					route.pathname ||
+					route.segments.map((segment) => segment.map((p) => p.content).join('')).join('/');
+				const computedMimeType = mime.getType(filepath);
 				if (computedMimeType) {
 					contentType = computedMimeType;
 				}

--- a/packages/astro/test/dev-routing.test.js
+++ b/packages/astro/test/dev-routing.test.js
@@ -246,6 +246,26 @@ describe('Development Routing', () => {
 			expect(body.slug).to.equal('thing4');
 			expect(body.title).to.equal('data [slug]');
 		});
+
+		it('correct MIME type when loading /home.json (static route)', async () => {
+			const response = await fixture.fetch('/home.json');
+			expect(response.headers.get('content-type')).to.match(/application\/json/);
+		});
+
+		it('correct MIME type when loading /thing1.json (dynamic route)', async () => {
+			const response = await fixture.fetch('/thing1.json');
+			expect(response.headers.get('content-type')).to.match(/application\/json/);
+		});
+
+		it('correct MIME type when loading /images/static.svg (static image)', async () => {
+			const response = await fixture.fetch('/images/static.svg');
+			expect(response.headers.get('content-type')).to.match(/image\/svg\+xml/);
+		});
+
+		it('correct MIME type when loading /images/1.svg (dynamic image)', async () => {
+			const response = await fixture.fetch('/images/1.svg');
+			expect(response.headers.get('content-type')).to.match(/image\/svg\+xml/);
+		});
 	});
 
 	describe('file format routing', () => {

--- a/packages/astro/test/fixtures/with-endpoint-routes/src/pages/images/[image].svg.ts
+++ b/packages/astro/test/fixtures/with-endpoint-routes/src/pages/images/[image].svg.ts
@@ -1,0 +1,14 @@
+export async function getStaticPaths() {
+	return [
+			{ params: { image: 1 } },
+			{ params: { image: 2 } },
+	];
+}
+
+export async function get({ params }) {
+	return {
+			body: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 200">
+	<title>${params.image}</title>
+</svg>`
+	};
+}

--- a/packages/astro/test/fixtures/with-endpoint-routes/src/pages/images/static.svg.ts
+++ b/packages/astro/test/fixtures/with-endpoint-routes/src/pages/images/static.svg.ts
@@ -1,0 +1,7 @@
+export async function get() {
+	return {
+			body: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 200">
+	<title>Static SVG</title>
+</svg>`
+	};
+}

--- a/packages/integrations/vercel/package.json
+++ b/packages/integrations/vercel/package.json
@@ -20,7 +20,7 @@
     "./edge/entrypoint": "./dist/edge/entrypoint.js",
     "./serverless": "./dist/serverless/adapter.js",
     "./serverless/entrypoint": "./dist/serverless/entrypoint.js",
-    "./static": "./dist/serverless/adapter.js",
+    "./static": "./dist/static/adapter.js",
     "./package.json": "./package.json"
   },
   "typesVersions": {


### PR DESCRIPTION

## Changes
  This enables the use of `{ output: static, adapter: vercelStaticAdapter}`.  

Previously, both paths, `@astro/vercel/static` and `@astro/vercel/serverless`, would resolve to the serverless adapter.

## Testing

Manually tested, observed build output changed from 
`[build] deploy adapter: @astrojs/vercel/serverless` to 
`[build] deploy adapter: @astrojs/vercel/static`

## Docs

nothing new to document
